### PR TITLE
Adding minitest to jiminy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,9 @@ gem "sprockets-rails"
 # Use postgres as the database
 gem "pg"
 
+# For Jiminy / Prosopite
+gem 'pg_query'
+
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", "~> 5.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,8 @@ GEM
     faraday-net_http (3.0.2)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    google-protobuf (3.22.3-arm64-darwin)
+    google-protobuf (3.22.3-x86_64-linux)
     i18n (1.13.0)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
@@ -141,6 +143,8 @@ GEM
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     pg (1.5.3)
+    pg_query (4.2.0)
+      google-protobuf (>= 3.19.2)
     prosopite (1.3.0)
     public_suffix (5.0.1)
     puma (5.6.5)
@@ -237,6 +241,7 @@ DEPENDENCIES
   jbuilder
   jiminy!
   pg
+  pg_query
   puma (~> 5.0)
   rails (~> 7.0.4)
   rspec-rails

--- a/app/controllers/desks_controller.rb
+++ b/app/controllers/desks_controller.rb
@@ -3,6 +3,9 @@ class DesksController < ApplicationController
 
   # GET /desks or /desks.json
   def index
+    @n_plus_oneing = Room.all.map do |room|
+      room.desks.map { |desk| desk.number }
+    end
     @desks = Desk.all
   end
 

--- a/test/integration/desks_test.rb
+++ b/test/integration/desks_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class BlogFlowTest < ActionDispatch::IntegrationTest
+  test "can see the welcome page" do
+    blue_room = FactoryBot.create(:room, name: "Blue room")
+    red_room = FactoryBot.create(:room, name: "Red room")
+    green_room = FactoryBot.create(:room, name: "Green room")
+    FactoryBot.create(:desk, room: blue_room)
+    FactoryBot.create(:desk, room: red_room)
+    FactoryBot.create(:desk, room: green_room)
+    FactoryBot.create(:desk, room: blue_room)
+    FactoryBot.create(:desk, room: red_room)
+    FactoryBot.create(:desk, room: green_room)
+
+    get desks_url
+    assert response
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,13 @@
+ENV['RAILS_ENV'] ||= 'test'
+require_relative "../config/environment"
+require "rails/test_help"
+
+class ActiveSupport::TestCase
+  # Run tests in parallel with specified workers
+  parallelize(workers: :number_of_processors)
+
+  # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
+  fixtures :all
+
+  # Add more helper methods to be used by all tests here...
+end


### PR DESCRIPTION
This setup combined with the [minitest branch](https://github.com/Bodacious/jiminy/pull/17) in Jiminy wrote to `tmp/jiminy/results.yml` when you run

`bundle exec rails test bundle exec test test/integration/desks_test.rb`


```
---
- app/controllers/desks_controller.rb:7:in `map':
    file: app/controllers/desks_controller.rb
    line: '7'
    method: map
    examples:
    - SELECT "desks".* FROM "desks" WHERE "desks"."room_id" = $1
    - SELECT "desks".* FROM "desks" WHERE "desks"."room_id" = $1
    - SELECT "desks".* FROM "desks" WHERE "desks"."room_id" = $1
```